### PR TITLE
Fix dev API URL helper

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -1,12 +1,16 @@
 import Constants from 'expo-constants';
 
 export const generateAPIUrl = (relativePath: string) => {
-  const origin = Constants.experienceUrl.replace('exp://', 'http://');
-
   const path = relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
 
   if (process.env.NODE_ENV === 'development') {
-    return origin.concat(path);
+    // Constants.experienceUrl isn't available on all platforms (e.g. web).
+    // Fallback to the current location when it isn't defined.
+    const devOrigin =
+      Constants.experienceUrl?.replace('exp://', 'http://') ??
+      (typeof location !== 'undefined' ? location.origin : '');
+
+    return devOrigin.concat(path);
   }
 
   if (!process.env.EXPO_PUBLIC_API_BASE_URL) {


### PR DESCRIPTION
## Summary
- handle undefined `experienceUrl` in `generateAPIUrl`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6882b418d680832a9acf1085da6e2cbb