### PR TITLE
Add Jest setup and tests for generateAPIUrl

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,34 @@
+jest.mock("expo-constants", () => ({ __esModule: true, default: {} }));
+import Constants from 'expo-constants';
+import { generateAPIUrl } from '../utils';
+
+describe('generateAPIUrl', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses Constants.experienceUrl in development', () => {
+    process.env.NODE_ENV = 'development';
+    (Constants as any).experienceUrl = 'exp://localhost:8081';
+    expect(generateAPIUrl('/test')).toBe('http://localhost:8081/test');
+  });
+
+  it('throws when base url undefined in production', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    expect(() => generateAPIUrl('/test')).toThrow();
+  });
+
+  it('combines base url with path in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.EXPO_PUBLIC_API_BASE_URL = 'https://example.com';
+    expect(generateAPIUrl('test')).toBe('https://example.com/test');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@ai-sdk/google": "^1.2.22",
@@ -48,7 +49,10 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest preset
- add devDependencies for Jest
- add a test script to package.json
- implement tests for `generateAPIUrl`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68831fd0e308832ab2d180246b5e5f3a